### PR TITLE
use 0.6.0-pre for julia minimum version in REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.6-
+julia 0.6.0-pre
 DeepDiffs


### PR DESCRIPTION
`struct` syntax won't work on early 0.6.0-dev versions,
so better to stick with the julia-0.5-compatible versions of the package there