### PR TITLE
Add `Test` as a real dependency

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "2.0.0"
 [deps]
 DeepDiffs = "ab62b9b5-e342-54a8-a765-a90f495de1a6"
 Distributed = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "1"
@@ -14,7 +15,6 @@ DeepDiffs = "1"
 [extras]
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Suppressor", "Test", "Logging"]
+test = ["Suppressor", "Logging"]


### PR DESCRIPTION
`TestSetExtensions` currently lists `Test` as a test-only dependency, which causes  `Pkg` to complain whenever `TestSetExtensions` is used in other contexts than its own tests:
```julia
julia> using TestSetExtensions
┌ Warning: Package TestSetExtensions does not have Test in its dependencies:
│ - If you have TestSetExtensions checked out for development and have
│   added Test as a dependency but haven't updated your primary
│   environment's manifest file, try `Pkg.resolve()`.
│ - Otherwise you may need to report an issue with TestSetExtensions
└ Loading Test into TestSetExtensions from project dependency, future warnings for TestSetExtensions are suppressed.
```

This PR fixes that by simply declaring `Test` as a standard dependency of `TestSetExtensions`.

Thanks for this package, and please keep up the good work!