### PR TITLE
improve error in comparing tuples

### DIFF
--- a/src/TestSetExtensions.jl
+++ b/src/TestSetExtensions.jl
@@ -75,6 +75,8 @@ function Test.record(ts::ExtendedTestSet{T}, res::Fail) where {T}
                         deepdiff(test_expr.args[2], test_expr.args[3])
                     elseif test_expr.args[2].head === :vect && test_expr.args[3].head === :vect
                         deepdiff(test_expr.args[2].args, test_expr.args[3].args)
+                    elseif test_expr.args[2].head === :tuple && test_expr.args[3].head === :tuple
+                        deepdiff([test_expr.args[2].args...], [test_expr.args[3].args...])
                     elseif test_expr.args[2].head === :call && test_expr.args[3].head === :call &&
                             test_expr.args[2].args[1].head === :curly && test_expr.args[3].args[1].head === :curly
                         deepdiff(Base.eval(test_expr.args[2].args), Base.eval(test_expr.args[3].args))


### PR DESCRIPTION
If comparing tuples, this will call `deepdiff` with the tuples expanded as vectors, and the `diff` message will be better. (instead of `nothing`).