### PR TITLE
The current implementation breaks for `Dict`, `Set`, etc due to the s…

### DIFF
--- a/src/TestSetExtensions.jl
+++ b/src/TestSetExtensions.jl
@@ -71,14 +71,7 @@ function Test.record(ts::ExtendedTestSet{T}, res::Fail) where {T}
                 end
 
                 if test_expr.head === :call && test_expr.args[1] === Symbol("==")
-                    dd = if isa(test_expr.args[2], String) && isa(test_expr.args[3], String)
-                        deepdiff(test_expr.args[2], test_expr.args[3])
-                    elseif test_expr.args[2].head === :vect && test_expr.args[3].head === :vect
-                        deepdiff(test_expr.args[2].args, test_expr.args[3].args)
-                    elseif test_expr.args[2].head === :call && test_expr.args[3].head === :call &&
-                            test_expr.args[2].args[1].head === :curly && test_expr.args[3].args[1].head === :curly
-                        deepdiff(Base.eval(test_expr.args[2].args), Base.eval(test_expr.args[3].args))
-                    end
+                    dd = deepdiff(Base.eval(test_expr.args[2]), Base.eval(test_expr.args[3]))
 
                     if ! isa(dd, DeepDiffs.SimpleDiff)
                         # The test was an comparison between things we can diff,


### PR DESCRIPTION
The current implementation breaks for `Dict`, `Set`, etc due to the specific implementation of #10, e.g.

```
julia> @testset ExtendedTestSet "begin" begin
           @test Dict(1 => 2) == Dict(2 => 2)
       end

=====================================================
begin: Test Failed at REPL[5]:2
  Expression: Dict(1 => 2) == Dict(2 => 2)
   Evaluated: Dict(1 => 2) == Dict(2 => 2)

<redacted>...
```

This PR will attempt to fix comparing of `Dict`, `Set`, etc while keeping the rest of the vectors and so on working.
```
julia> @testset ExtendedTestSet "begin" begin
           @test Dict(1 => 2) == Dict(2 => 2)
       end

=====================================================
begin: Test Failed
  Expression: Dict(1 => 2) == Dict(2 => 2)

Diff:
Dict(
-    1 => 2,
+    2 => 2,
)

<redacted>...
```

We achieved this by reverting to the implementation before the change. That is, to just evaluate regardless of what the LHS and RHS are in a `@test LHS == RHS` statement. There is one con, which is that `deepdiff` currently doesn't compare everything sufficiently well yet, especially if the objects are not part of the Julia base. This however should be an improvement that we will want to delegate to [DeepDiffs.jl](https://github.com/ssfrr/DeepDiffs.jl), which is good as that gives us a new good reason to help make improvement to that project 💪