### PR TITLE
Enable failfast for ExtendedTestSet by adding compatibility with FallbackTestSet.

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,7 +39,7 @@ try
 catch
 end
 
-@testset ExtendedTestSet "TextSetExtensions Tests" begin
+@testset ExtendedTestSet "TestSetExtensions Tests" begin
     @testset "check output dots" begin
         @test split(output, '\n')[1] == "...."
     end


### PR DESCRIPTION
The current implementation does not support failfast because FallbackTestSet does not possess the same fields as DefaultTestSet. This PR adds support for failfast by adding compatibility with FallbackTestSet. Compatibility with FallbackTestSet is achieved by specializing the type for the original Test.record() method to ExtendedTestSet{DefaultTestSet} and adding a record(ts::ExtendedTestSet{T}, res::Fail) method that calls the record method for T.

One of the issues that arises when using FallbackTestSet is the generation of redundant error messages when test sets are nested. In this PR, this issues is addressed by suppressing  output messages originating from errors generated when a test set detects that an enclosed test or test set has failed (via the introduction of a ExtendedTestSetException to distinguish between the original test failure/error and subsequent test errors).

Unit tests have been added to verify the expected failfast behavior.