### PR TITLE
fix result propagation for nested testsets on Julia < 1.12

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestSetExtensions"
 uuid = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
-version = "4.0.1"
+version = "4.0.2"
 authors = ["Spencer Russell", "Phillip Alday"]
 
 [deps]

--- a/src/TestSetExtensions.jl
+++ b/src/TestSetExtensions.jl
@@ -114,6 +114,27 @@ function Test.record(ts::ExtendedTestSet{T}, res) where {T}
     return res
 end
 
+# On Julia < 1.12, get_test_counts(::DefaultTestSet) only processes isa(t, DefaultTestSet)
+# children. Plain @testset nested inside an ExtendedTestSet inherits the parent's type,
+# creating another ExtendedTestSet, which is then silently skipped by get_test_counts.
+# This helper replaces ExtendedTestSet children with their wrapped DefaultTestSets just
+# before the root finish, making counts work correctly. It runs after all testset body
+# code (including TestReports assertions) has already completed.
+@static if !isdefined(Test, :TestCounts)
+    function _flatten_for_counting!(ts::DefaultTestSet)
+        for i in eachindex(ts.results)
+            t = ts.results[i]
+            if t isa ExtendedTestSet
+                isnothing(t.wrapped.time_end) && (t.wrapped.time_end = time())
+                ts.results[i] = t.wrapped
+                _flatten_for_counting!(t.wrapped)
+            elseif t isa DefaultTestSet
+                _flatten_for_counting!(t)
+            end
+        end
+    end
+end
+
 function Test.finish(ts::ExtendedTestSet{T}; print_results::Bool=Test.TESTSET_PRINT_ENABLE[]) where {T}
     Test.get_testset_depth() == 0 && print("\n\n")
     if Test.get_testset_depth() != 0
@@ -123,6 +144,9 @@ function Test.finish(ts::ExtendedTestSet{T}; print_results::Bool=Test.TESTSET_PR
         return ts
     end
 
+    @static if !isdefined(Test, :TestCounts)
+        _flatten_for_counting!(ts.wrapped)
+    end
     Test.finish(ts.wrapped; print_results)
     return ts
 end

--- a/src/TestSetExtensions.jl
+++ b/src/TestSetExtensions.jl
@@ -152,9 +152,15 @@ function Test.finish(ts::ExtendedTestSet{T}; print_results::Bool=Test.TESTSET_PR
 end
 
 function Test.print_test_results(ts::ExtendedTestSet{T}, args...) where {T}
+    @static if !isdefined(Test, :TestCounts)
+        _flatten_for_counting!(ts.wrapped)
+    end
     return Test.print_test_results(ts.wrapped, args...)
 end
-function Test.get_test_counts(ts::ExtendedTestSet{T}) where {T} 
+function Test.get_test_counts(ts::ExtendedTestSet{T}) where {T}
+    @static if !isdefined(Test, :TestCounts)
+        _flatten_for_counting!(ts.wrapped)
+    end
     return Test.get_test_counts(ts.wrapped)
 end
 

--- a/test/display.jl
+++ b/test/display.jl
@@ -19,7 +19,7 @@ end
         nested_tests()
     end
 
-    dts = @testset Test.DefaultTestSet "testset" begin
+    dts = @testset DefaultTestSet "testset" begin
         nested_tests()
     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using Test
+using Test: DefaultTestSet
 using TestSetExtensions
 using Aqua
 using MetaTesting

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,10 +10,27 @@ using EzXML
 
 using MetaTesting: EncasedTestSet
 
+# Regression test for Julia < 1.12: plain @testset nested inside an ExtendedTestSet
+# inherits the parent's type, producing ExtendedTestSet children that Julia 1.10's
+# get_test_counts (which checks isa(t, DefaultTestSet)) silently skips, showing "None 0.0s".
+output = @capture_out begin
+    @testset ExtendedTestSet "result propagation" begin
+        @testset "nested" begin
+                @test true
+        end
+    end
+end
+
 @testset ExtendedTestSet "TextSetExtensions Tests" begin
     @testset "Aqua" begin
         Aqua.test_all(TestSetExtensions)
     end
+    
+    @testset "ExtendedTestSet result propagation" begin
+        @test occursin("Pass", output)
+        @test !occursin("None", output)
+    end
+
     @testset "progress" begin
         include("progress.jl")
     end
@@ -40,21 +57,5 @@ using MetaTesting: EncasedTestSet
 
         xml = report(ts)
         @test length(collect(eachnode(root(xml)))) == 3
-    end
-end
-
-# Regression test for Julia < 1.12: plain @testset nested inside an ExtendedTestSet
-# inherits the parent's type, producing ExtendedTestSet children that Julia 1.10's
-# get_test_counts (which checks isa(t, DefaultTestSet)) silently skips, showing "None 0.0s".
-let output = @capture_out begin
-    @testset ExtendedTestSet "result propagation" begin
-        @testset "nested" begin
-            @test true
-        end
-    end
-end
-    @testset "ExtendedTestSet result propagation" begin
-        @test occursin("Pass", output)
-        @test !occursin("None", output)
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -41,3 +41,19 @@ using MetaTesting: EncasedTestSet
         @test length(collect(eachnode(root(xml)))) == 3
     end
 end
+
+# Regression test for Julia < 1.12: plain @testset nested inside an ExtendedTestSet
+# inherits the parent's type, producing ExtendedTestSet children that Julia 1.10's
+# get_test_counts (which checks isa(t, DefaultTestSet)) silently skips, showing "None 0.0s".
+let output = @capture_out begin
+    @testset ExtendedTestSet "result propagation" begin
+        @testset "nested" begin
+            @test true
+        end
+    end
+end
+    @testset "ExtendedTestSet result propagation" begin
+        @test occursin("Pass", output)
+        @test !occursin("None", output)
+    end
+end


### PR DESCRIPTION
closes #41 

## Summary

- On Julia 1.10, plain `@testset` nested inside an `ExtendedTestSet` inherits the parent's type (standard Julia `@testset` behaviour), producing `ExtendedTestSet` children instead of `DefaultTestSet`
- Julia 1.10's `get_test_counts(::DefaultTestSet)` only counts `isa(t, DefaultTestSet)` children, so nested `ExtendedTestSet`s are silently skipped — the summary shows "None 0.0s" instead of the correct pass count
- Julia 1.12 fixed this in stdlib by changing the check to `isa(t, AbstractTestSet)` and introducing `TestCounts`
- Julia 1.10's `@testset` macro also rejects qualified type names (e.g. `Test.DefaultTestSet`) as the testset type argument; the test suite used this form in `display.jl`

The fix adds `_flatten_for_counting!`, guarded by `@static if !isdefined(Test, :TestCounts)`, which recursively replaces `ExtendedTestSet` children with their `wrapped` `DefaultTestSet` in `ts.wrapped.results` before any counting operation (`finish`, `print_test_results`, `get_test_counts`). This runs after all testset body code has completed, so TestReports compatibility (`report(ts)` called inside the block) is unaffected.

The test suite is also fixed: `using Test: DefaultTestSet` is added to `runtests.jl` so `display.jl` can use the bare name in `@testset DefaultTestSet`.

## Test plan

- [x] New root-level regression test captures the summary output of an `ExtendedTestSet` with a nested plain `@testset`, asserting `occursin("Pass", output)` and `!occursin("None", output)`
- [x] Run `julia +1.10 --project=. -E'using Pkg; Pkg.test()'` — all 21 tests pass, summary no longer shows "None 0.0s"
- [x] Run on Julia 1.12 to confirm no regression on newer Julia

🤖 Generated with [Claude Code](https://claude.com/claude-code)