### PR TITLE
fix compatibility with Julia 1.13 const DefaultTestSet.description

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TestSetExtensions"
 uuid = "98d24dd4-01ad-11ea-1b02-c9a08f80db04"
-version = "4.0.2"
+version = "4.0.3"
 authors = ["Spencer Russell", "Phillip Alday"]
 
 [deps]

--- a/src/TestSetExtensions.jl
+++ b/src/TestSetExtensions.jl
@@ -5,12 +5,13 @@ using Test: AbstractTestSet, DefaultTestSet
 using Test: Result, Fail, Error, Pass
 export ExtendedTestSet
 
-struct ExtendedTestSet{T<:AbstractTestSet} <: AbstractTestSet
-    wrapped::T
+mutable struct ExtendedTestSet{T<:AbstractTestSet} <: AbstractTestSet
+    const wrapped::T
+    description::String
     # for compatibility with TestReports
-    testset_properties::Vector{Pair{String, Any}}
-    test_properties::Vector{Pair{String, Any}}
-    ExtendedTestSet{T}(desc) where {T} = new(T(desc), Pair{String, Any}[], Pair{String, Any}[])
+    const testset_properties::Vector{Pair{String, Any}}
+    const test_properties::Vector{Pair{String, Any}}
+    ExtendedTestSet{T}(desc) where {T} = new(T(desc), desc, Pair{String, Any}[], Pair{String, Any}[])
 end
 
 function Base.getproperty(t::T, s::Symbol) where {T <: ExtendedTestSet}
@@ -24,9 +25,11 @@ end
 
 function Base.setproperty!(t::T, s::Symbol, v) where {T <: ExtendedTestSet}
     @debug "set $s"
-    # ExtendedTestSet is immutable and has no properties you can set
-    # so we can assume delegation
-    return setproperty!(t.wrapped, s, v)
+    if s ∈ fieldnames(T)
+        return setfield!(t, s, v)
+    else
+        return setproperty!(t.wrapped, s, v)
+    end
 end
 
 struct FailDiff <: Result


### PR DESCRIPTION
## Summary

- Julia 1.13 made `DefaultTestSet.description` a `const` field
- TestReports' `_flatten_results!` sets `description` on `ExtendedTestSet` children during `report(ts)`
- Our `setproperty!` was delegating all writes to `t.wrapped`, hitting `setfield!` on a const field and erroring

The fix makes `ExtendedTestSet` a `mutable struct` with `description` as its own mutable field (all others marked `const`). `setproperty!` now mirrors the existing `getproperty` pattern: use `setfield!` for fields belonging to `ExtendedTestSet` itself, delegate to `wrapped` for everything else.

## Test plan

- [x] `julia +1.13 --startup-file=no --project=. -E'using Pkg; Pkg.test()'` — all 23 tests pass
- [x] `julia +1.10 --startup-file=no --project=. -E'using Pkg; Pkg.test()'` — all 23 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)